### PR TITLE
Change unfollow to stop-following

### DIFF
--- a/src/eu/e43/impeller/fragment/PersonObjectFragment.java
+++ b/src/eu/e43/impeller/fragment/PersonObjectFragment.java
@@ -148,7 +148,7 @@ public class PersonObjectFragment extends ObjectFragment implements CompoundButt
                 if(state)
                     action = "follow";
                 else
-                    action = "unfollow";
+                    action = "stop-following";
 
                 JSONObject act = new JSONObject();
                 act.put("verb", action);


### PR DESCRIPTION
When you stop following a user, the standard verb of this activity (used by other clients) is “stop-following” (according to http://activitystrea.ms/head/activity-schema.html#verbs), but impeller posts it as “unfollow”, which is not included in ms_verbStrings for localization.

So we are in a curious situation where Impeller doesn't understand it's own activities.

We could either add “unfollow” to ms_verbStrings and point it to the same localized string as “stop-following”, or we can change it to “stop-following” comply with the activitystrea.ms standard. I would say this solution has the advantage of compatibility with other pump.io clients. Introducing new verbs for the same action would add more complexity other developers will have to deal with if they want to parse actions or implement i18n in their applications.
