### PR TITLE
Fix string value format for transifex compatibility

### DIFF
--- a/res/values/strings_fragment_object_null.xml
+++ b/res/values/strings_fragment_object_null.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="object_null_title"   value="Oh dear..."/>
-    <string name="object_null_message" value="There doesn't appear to be anything here..." />
+  <string name="object_null_title">Oh dear...</string>
+  <string name="object_null_message">There doesn't appear to be anything here...</string>
 </resources>


### PR DESCRIPTION
Transifex doesn't support this special form of string values written as attributes, it just says no values were found - I had to change this file to normal format to import it. This means that the automatic webhook importing mechanism will overlook any strings written in that attribute form.
