### PR TITLE
Replace comment_meta_at

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -108,5 +108,4 @@
 
     <string name="actor_unknown">Neznámý</string>
     <string name="comment_meta_by">Od</string>
-    <string name="comment_meta_at">,</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -108,5 +108,4 @@
     
     <string name="actor_unknown">Unknown</string>
     <string name="comment_meta_by">By</string>
-    <string name="comment_meta_at">\u0020at</string>
 </resources>

--- a/res/values/strings_fragment_object_null.xml
+++ b/res/values/strings_fragment_object_null.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="object_null_title">Oh dear...</string>
-  <string name="object_null_message">There doesn't appear to be anything here...</string>
+  <string name="object_null_message">There doesn\'t appear to be anything here...</string>
 </resources>

--- a/src/eu/e43/impeller/uikit/CommentAdapter.java
+++ b/src/eu/e43/impeller/uikit/CommentAdapter.java
@@ -92,8 +92,7 @@ public class CommentAdapter extends BaseAdapter implements LoaderManager.LoaderC
 				activity.getImageLoader().setImage(authorAvatar, Utils.getImageUrl(imageObj));
 
             commentMeta.setText(m_ctx.getResources().getString(R.string.comment_meta_by) + " "
-				+ author.optString("displayName")
-				+ m_ctx.getResources().getString(R.string.comment_meta_at) + " "
+				+ author.optString("displayName") + ", "
 				+ Utils.humanDate(comment.optString("published")));
 		}
 


### PR DESCRIPTION
I created the comment_meta_at to preserve the “at” in English, while allowing languages that have no such preposition for dates (such as Czech) to use a comma.

Now I realized English doesn't need this either. You don't say “comment by Evan Prodromou at 28 April 2014”. “At” would only be used for times of the day. And other languages will have their own specifics. So why not just use the comma to avoid confusing translators with all this “\u0020at” business?

Plus a backslash that is now required before an apostrophe.
