### PR TITLE
Fix bug: screen rotation erases unfinished text

### DIFF
--- a/src/eu/e43/impeller/fragment/StandardObjectFragment.java
+++ b/src/eu/e43/impeller/fragment/StandardObjectFragment.java
@@ -93,6 +93,14 @@ public class StandardObjectFragment extends ObjectFragment implements View.OnCli
 
         if(savedInstanceState != null) {
             m_account = savedInstanceState.getParcelable("account");
+            String replyText = savedInstanceState.getString("replyText");
+            if(replyText!=null)
+            {
+                View root = getView();
+                ListView lv = (ListView) root.findViewById(android.R.id.list);
+                EditText editor = (EditText) lv.findViewById(R.id.replyText);
+                editor.setText(replyText);
+            }
         } else {
             m_account = getMainActivity().getAccount();
         }
@@ -235,6 +243,16 @@ public class StandardObjectFragment extends ObjectFragment implements View.OnCli
         ).putExtra("account", getMainActivity().getAccount()), null);
 
         return lv;
+    }
+
+    @Override
+    public void onSaveInstanceState (Bundle outState)
+    {
+        View root = getView();
+        if(root == null) return;
+        ListView lv = (ListView) root.findViewById(android.R.id.list);
+        EditText editor = (EditText) lv.findViewById(R.id.replyText);
+        outState.putString("replyText", editor.getText().toString());
     }
 
     @Override


### PR DESCRIPTION
Problem: If you start writing a comment, and you tilt your smartphone to the side before you send it, your text will be lost and you have to start typing it again. This could be annoying if a user is forced to retype a long reply.

Cause: Reply text is not saved in the instance state. Automatic saving mechanism doesn't see the EditText field, probably because we create it dynamically.

Solution: Explicitly keep the unfinished reply text in instance state to avoid loosing it on screen rotation.
